### PR TITLE
Add notes to files

### DIFF
--- a/app/graphql/mutations/update_file_notes.rb
+++ b/app/graphql/mutations/update_file_notes.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Mutations
+  class UpdateFileNotes < Mutations::BaseMutation
+    description 'Mutation to update the notes attached to a file. Supports Markdown.'
+
+    argument :id, ID, required: true
+    argument :notes,
+             String,
+             required: true
+
+    field :file, Types::FileType, null: true
+
+    def resolve(id:, notes:)
+      file = FileManager::File.find(id)
+
+      if file.update!(notes: notes)
+        { file: file }
+      else
+        { file: nil }
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -6,5 +6,6 @@ module Types
     field :unarchiveFiles, mutation: Mutations::UnarchiveFiles
     field :uploadFile, mutation: Mutations::UploadFile
     field :updateFile, mutation: Mutations::UpdateFile
+    field :updateFileNotes, mutation: Mutations::UpdateFileNotes
   end
 end

--- a/app/ui/Sections/Files/FilesList/FilesList.jsx
+++ b/app/ui/Sections/Files/FilesList/FilesList.jsx
@@ -1,21 +1,19 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import ReactMarkdown from 'react-markdown'
 
 import { useQuery, useMutation } from '@apollo/client'
 import Files from './graphql/Files.graphql'
 import UploadFile from './graphql/UploadFile.graphql'
 import ArchiveFiles from './graphql/ArchiveFiles.graphql'
 import UnarchiveFiles from './graphql/UnarchiveFiles.graphql'
-import UpdateFileNotes from './graphql/UpdateFileNotes.graphql'
 
-import { Table, Upload, Statistic, Spin, Button, Form, Tabs, Space, Row, Col, Input } from 'antd'
+import { Table, Upload, Statistic, Spin, Button, Form, Tabs, Space } from 'antd'
 import { InboxOutlined } from '@ant-design/icons'
+import FileDetails from './components/fileDetails/FileDetails.jsx'
 
 const filesize = require('file-size')
 
 const { Dragger } = Upload
-const { TextArea } = Input
 
 export default function PrintersList () {
   const filters = {
@@ -36,26 +34,6 @@ export default function PrintersList () {
         query: Files,
         data: {
           files: [...filesdata.files, data.uploadFile.file]
-        }
-      })
-    }
-  })
-
-  const [updateFileNotes] = useMutation(UpdateFileNotes, {
-    update: (cache, { data }) => {
-      const filesdata = cache.readQuery({ query: Files })
-
-      const filteredFiles = filesdata.files.map((file) => {
-        if (selectedRowKeys.indexOf(file.id) !== -1) {
-          return data.updateFileNotes.file
-        }
-        return file
-      })
-
-      cache.writeQuery({
-        query: Files,
-        data: {
-          files: filteredFiles
         }
       })
     }
@@ -117,7 +95,6 @@ export default function PrintersList () {
       defaultSortOrder: 'ascend',
       sorter: (a, b) => a.filename.localeCompare(b.filename),
       render: (file) => {
-        console.log(file)
         return (<Link to={'/files/' + file.id}>{file.filename}</Link>)
       }
       // render: (file) => {
@@ -174,43 +151,6 @@ export default function PrintersList () {
     console.log('params', pagination, filters, sorter, extra)
   }
 
-  const onNotesSave = (values) => {
-    updateFileNotes({ variables: { input: { id: values.id, notes: values.notes } } })
-  }
-
-  const expandedRow = (record) => {
-    return (
-      <Row>
-        <Col span={12}>
-          <pre style={{ margin: 0 }}>{record.topFileComments}</pre>
-        </Col>
-        <Col span={12}>
-          <ReactMarkdown>
-            {record.notes}
-          </ReactMarkdown>
-          <Form
-            name={`fileNotes[${record.id}]`}
-            onFinish={onNotesSave}
-            autoComplete="off"
-            initialValues={{ notes: record.notes, id: record.id }}
-            >
-            <Form.Item hidden name="id" >
-              <Input />
-            </Form.Item>
-            <Form.Item name="notes">
-              <TextArea rows={10} />
-            </Form.Item>
-            <Form.Item>
-              <Button type="primary" htmlType="submit">
-                Save
-              </Button>
-            </Form.Item>
-          </Form>
-        </Col>
-      </Row>
-    )
-  }
-
   const props = {
     name: 'upload',
     multiple: true,
@@ -257,6 +197,12 @@ export default function PrintersList () {
 
   const handleTabChange = (key) => {
     setFilesFilters(key)
+  }
+
+  const expandedRow = (record) => {
+    return (
+      <FileDetails record={record} />
+    )
   }
 
   return (

--- a/app/ui/Sections/Files/FilesList/FilesList.jsx
+++ b/app/ui/Sections/Files/FilesList/FilesList.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
 
 import { useQuery, useMutation } from '@apollo/client'
 import Files from './graphql/Files.graphql'
@@ -7,7 +8,7 @@ import UploadFile from './graphql/UploadFile.graphql'
 import ArchiveFiles from './graphql/ArchiveFiles.graphql'
 import UnarchiveFiles from './graphql/UnarchiveFiles.graphql'
 
-import { Table, Upload, Statistic, Spin, Button, Form, Tabs, Space, Descriptions } from 'antd'
+import { Table, Upload, Statistic, Spin, Button, Form, Tabs, Space, Row, Col } from 'antd'
 import { InboxOutlined } from '@ant-design/icons'
 
 const filesize = require('file-size')
@@ -152,16 +153,16 @@ export default function PrintersList () {
 
   const expandedRow = (record) => {
     return (
-      <Descriptions
-        layout="vertical"
-      >
-        <Descriptions.Item label="Top file comments">
+      <Row>
+        <Col span={12}>
           <pre style={{ margin: 0 }}>{record.topFileComments}</pre>
-        </Descriptions.Item>
-        <Descriptions.Item label="Notes">
-          {record.notes}
-        </Descriptions.Item>
-      </Descriptions>
+        </Col>
+        <Col span={12}>
+          <ReactMarkdown>
+            {record.notes}
+          </ReactMarkdown>
+        </Col>
+      </Row>
     )
   }
 

--- a/app/ui/Sections/Files/FilesList/components/FileDetails/FileDetails.jsx
+++ b/app/ui/Sections/Files/FilesList/components/FileDetails/FileDetails.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { Button, Form, Row, Col, Input, Card, Space } from 'antd'
+import ReactMarkdown from 'react-markdown'
+
+import UpdateFileNotes from '../../graphql/UpdateFileNotes.graphql'
+import Files from '../../graphql/Files.graphql'
+
+import { useMutation } from '@apollo/client'
+import { EditOutlined } from '@ant-design/icons'
+
+const { TextArea } = Input
+
+function FileDetails ({ record }) {
+  const [updateFileNotes] = useMutation(UpdateFileNotes, {
+    update: (cache, { data }) => {
+      const filesdata = cache.readQuery({ query: Files })
+
+      const filteredFiles = filesdata.files.map((file) => {
+        if (file.id === data.updateFileNotes.file.id) {
+          return data.updateFileNotes.file
+        }
+        return file
+      })
+
+      cache.writeQuery({
+        query: Files,
+        data: {
+          files: filteredFiles
+        }
+      })
+    }
+  })
+
+  const [editMode, setEditMode] = useState(false)
+
+  const onNotesSave = (values) => {
+    updateFileNotes({ variables: { input: { id: values.id, notes: values.notes } } })
+    toggleEdit()
+  }
+
+  const toggleEdit = () => {
+    setEditMode(!editMode)
+  }
+
+  return (
+    <Row>
+      <Col span={12}>
+        <pre style={{ margin: 0 }}>{record.topFileComments}</pre>
+      </Col>
+      <Col span={12}>
+        { editMode === true
+          ? <Form
+          name={'FileNotesForm'}
+          onFinish={onNotesSave}
+          autoComplete="off"
+          initialValues={{ notes: record.notes, id: record.id }}
+          >
+          <Form.Item hidden name="id" >
+            <Input />
+          </Form.Item>
+          <Form.Item name="notes">
+            <TextArea rows={10} />
+          </Form.Item>
+          <Form.Item>
+            <Space>
+              <Button type="primary" htmlType="submit">
+                Save
+              </Button>
+              <Button onClick={toggleEdit}>Cancel</Button>
+            </Space>
+          </Form.Item>
+        </Form>
+          : <Card title="Notes" extra={<EditOutlined onClick={toggleEdit}/>}>
+          <ReactMarkdown>
+            {record.notes}
+          </ReactMarkdown>
+          </Card>
+        }
+      </Col>
+    </Row>
+  )
+}
+
+FileDetails.propTypes = {
+  record: PropTypes.object.isRequired
+}
+
+export default FileDetails

--- a/app/ui/Sections/Files/FilesList/graphql/UpdateFileNotes.graphql
+++ b/app/ui/Sections/Files/FilesList/graphql/UpdateFileNotes.graphql
@@ -1,0 +1,8 @@
+#import "./FileFragment.graphql"
+mutation UpdateFileNotes($input: UpdateFileNotesInput!) {
+  updateFileNotes(input: $input) {
+    file {
+      ...FileFields
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/sophiedeziel/Tentacles/issues/4

Notes support markdown to allow users to add formatted documentation on their files. They can view and edit notes by expanding the file's row in the files list view. 