### PR TITLE
Print job queues data model

### DIFF
--- a/app/graphql/types/job_type.rb
+++ b/app/graphql/types/job_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class JobType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :status, String, null: true
+    field :executable, Types::FileType, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/printer_type.rb
+++ b/app/graphql/types/printer_type.rb
@@ -14,5 +14,9 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     field :jobs, Types::JobType.connection_type, null: false
+    field :jobs_count, Integer, null: false
+    def jobs_count
+      object.jobs.count
+    end
   end
 end

--- a/app/graphql/types/printer_type.rb
+++ b/app/graphql/types/printer_type.rb
@@ -13,5 +13,6 @@ module Types
     field :job_status, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :jobs, Types::JobType.connection_type, null: false
   end
 end

--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class Printer < ApplicationRecord
+  has_many :jobs, class_name: 'Printer::Job', dependent: :nullify
+
+  def self.table_name_prefix
+    return '' if self == Printer
+
+    'printer_'
+  end
+
   def octoprint_version
     using_api do
       return Octoprint::ServerVersion.get

--- a/app/models/printer/job.rb
+++ b/app/models/printer/job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Printer
+  class Job < ApplicationRecord
+    belongs_to :printer
+    belongs_to :executable, polymorphic: true
+  end
+end

--- a/app/ui/Foundation/AppLayout/components/SideMenu.jsx
+++ b/app/ui/Foundation/AppLayout/components/SideMenu.jsx
@@ -59,9 +59,9 @@ function SideMenu () {
       Projects
     </Menu.Item>
     <SubMenu key="printers" icon={<UsbOutlined />} title="Printers">
-      <Menu.Item key="/printers">Manage</Menu.Item>
+      <Menu.Item key="/printers">Print Queues</Menu.Item>
+      <Menu.Item key="/printers/manage">Manage</Menu.Item>
       <Menu.Item key="/printers/operations">Operations</Menu.Item>
-      <Menu.Item key="/printers/option2">option2</Menu.Item>
     </SubMenu>
     <Menu.Item key="/files" icon={<FileOutlined />}>
       Files

--- a/app/ui/Foundation/AppSwitcher/AppSwitcher.jsx
+++ b/app/ui/Foundation/AppSwitcher/AppSwitcher.jsx
@@ -7,6 +7,7 @@ import {
 
 const Dashboard = lazy(() => import('../../Sections/Dashboard/Dashboard'))
 const PrintersList = lazy(() => import('../../Sections/Printers/PrintersList/PrintersList'))
+const QueuesList = lazy(() => import('../../Sections/Printers/QueuesList/QueuesList'))
 const FilesList = lazy(() => import('../../Sections/Files/FilesList/FilesList'))
 const FileEditor = lazy(() => import('../../Sections/Files/FileEditor/FileEditor'))
 const FilePrinter = lazy(() => import('../../Sections/Files/FilePrinter/FilePrinter'))
@@ -15,7 +16,8 @@ export default function AppSwithcer () {
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <Switch>
-          <Route path="/printers" exact component={PrintersList} />
+          <Route path="/printers" exact component={QueuesList} />
+          <Route path="/printers/manage" exact component={PrintersList} />
           <Route path="/files" exact component={FilesList} />
           <Route path="/files/:fileId/print" component={FilePrinter} />
           <Route path="/files/:fileId" component={FileEditor} />

--- a/app/ui/Sections/Printers/QueuesList/QueuesList.jsx
+++ b/app/ui/Sections/Printers/QueuesList/QueuesList.jsx
@@ -18,7 +18,7 @@ export default function QueuesList () {
       printers.map((printer) => {
         return (
         <li key={printer.id}>
-          {printer.name}
+          {printer.name}, {printer.jobStatus}, {printer.jobsCount} jobs in queue
         </li>
         )
       })

--- a/app/ui/Sections/Printers/QueuesList/QueuesList.jsx
+++ b/app/ui/Sections/Printers/QueuesList/QueuesList.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { useQuery } from '@apollo/client'
+import Printers from './graphql/Printers.graphql'
+
+export default function QueuesList () {
+  const { loading, error, data: printersData } = useQuery(Printers)
+
+  if (error) return (<>Error!{error.message}</>)
+
+  if (loading) return (<>Loading</>)
+
+  const { printers } = printersData
+
+  return (
+    <>
+      <ul>{
+      printers.map((printer) => {
+        return (
+        <li key={printer.id}>
+          {printer.name}
+        </li>
+        )
+      })
+      }
+      </ul>
+    </>
+  )
+}

--- a/app/ui/Sections/Printers/QueuesList/graphql/Printers.graphql
+++ b/app/ui/Sections/Printers/QueuesList/graphql/Printers.graphql
@@ -1,0 +1,11 @@
+query Printers {
+  printers {
+    id
+    name
+    octoprintUri
+    octoprintKey
+    octoprintVersion
+    createdAt
+    updatedAt
+  }
+}

--- a/app/ui/Sections/Printers/QueuesList/graphql/Printers.graphql
+++ b/app/ui/Sections/Printers/QueuesList/graphql/Printers.graphql
@@ -1,10 +1,9 @@
 query Printers {
   printers {
     id
+    jobsCount
     name
-    octoprintUri
-    octoprintKey
-    octoprintVersion
+    jobStatus
     createdAt
     updatedAt
   }

--- a/db/migrate/20220414021340_create_printer_jobs.rb
+++ b/db/migrate/20220414021340_create_printer_jobs.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreatePrinterJobs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :printer_jobs do |t|
+      t.string :name
+      t.references :printer, null: false, foreign_key: true
+      t.integer :executable_id, null: false
+      t.string :executable_type, null: false
+      t.string :status, null: false, default: 'enqueued'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_20_050845) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_14_021340) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -47,6 +47,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_20_050845) do
     t.datetime "archived_at", precision: nil
   end
 
+  create_table "printer_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.bigint "printer_id", null: false
+    t.integer "executable_id", null: false
+    t.string "executable_type", null: false
+    t.string "status", default: "enqueued", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["printer_id"], name: "index_printer_jobs_on_printer_id"
+  end
+
   create_table "printers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "octoprint_uri"
@@ -57,4 +68,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_20_050845) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "printer_jobs", "printers"
 end


### PR DESCRIPTION
Closes #35 

- Adds the database model for print jobs
- Adds the ActiveModel models and associations
- Add the GraphQL type to query
- Adds a queues list page
- View the number of jobs per printer queues on the queues list page