### PR TITLE
Fixed the display of the octoprint's version for a printer

### DIFF
--- a/app/graphql/types/printer_type.rb
+++ b/app/graphql/types/printer_type.rb
@@ -7,6 +7,9 @@ module Types
     field :octoprint_uri, String, null: true
     field :octoprint_key, String, null: true
     field :octoprint_version, String, null: true
+    def octoprint_version
+      object.octoprint_version.text
+    end
     field :job_status, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -14,7 +14,7 @@ class Printer < ApplicationRecord
   def octoprint_version
     using_api do
       Octoprint::ServerVersion.get
-    end&.text
+    end
   rescue StandardError
     nil
   end

--- a/app/models/printer.rb
+++ b/app/models/printer.rb
@@ -13,7 +13,7 @@ class Printer < ApplicationRecord
 
   def octoprint_version
     using_api do
-      return Octoprint::ServerVersion.get
+      Octoprint::ServerVersion.get
     end&.text
   rescue StandardError
     nil


### PR DESCRIPTION
The model needs to return an octoprint-specific object for internal usage but the correct string value has to be surfaced for GraphQL.