### PR TITLE
Put `@babel/plugin-proposal-object-rest-spread` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-merge": "5"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@webpack-cli/serve": "^1.6.1",
     "css-loader": "^6.8.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
The dev dependency is missing and makes https://github.com/sophiedeziel/Tentacles/pull/717 fail CI