### PR TITLE
Used a different form of file path generation for future linter updates

### DIFF
--- a/app/jobs/upload_files_to_printers_job.rb
+++ b/app/jobs/upload_files_to_printers_job.rb
@@ -21,7 +21,7 @@ class UploadFilesToPrintersJob < ApplicationJob
   def move_files(files)
     files.map do |file|
       file.blob.open do |temp_file|
-        temp_filename = "#{Rails.root}/tmp/#{file.filename}"
+        temp_filename = Rails.root.join("tmp/#{file.filename}")
         FileUtils.copy(temp_file.path, temp_filename)
         temp_filename
       end

--- a/app/models/file_manager/file.rb
+++ b/app/models/file_manager/file.rb
@@ -57,7 +57,7 @@ module FileManager
     end
 
     def change_file_content!(content)
-      temp_filename = "#{Rails.root}/tmp/#{file.filename}"
+      temp_filename = Rails.root.join("tmp/#{file.filename}")
       ::File.write(temp_filename, content)
       file.attach(io: ::File.open(temp_filename), filename:)
     end

--- a/spec/jobs/upload_files_to_printers_job_spec.rb
+++ b/spec/jobs/upload_files_to_printers_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UploadFilesToPrintersJob, type: :job do
       printer = create(:printer)
       file = create(:file_manager_file)
 
-      expect_any_instance_of(Printer).to receive(:upload).with("#{Rails.root}/tmp/#{file.filename}")
+      expect_any_instance_of(Printer).to receive(:upload).with(Rails.root.join("tmp/#{file.filename}"))
 
       UploadFilesToPrintersJob.perform_now([file.id], [printer.id])
     end


### PR DESCRIPTION
Will make https://github.com/sophiedeziel/Tentacles/pull/739 pass after a rebase.