### PR TITLE
Bring back the purple layout

### DIFF
--- a/app/ui/Foundation/AppLayout/AppLayout.jsx
+++ b/app/ui/Foundation/AppLayout/AppLayout.jsx
@@ -15,14 +15,34 @@ const { Header, Content, Footer, Sider } = Layout
 const darkTheme = {
   algorithm: [theme.darkAlgorithm],
   token: {
-    colorPrimary: '#a565ff'
+    colorPrimary: '#a565ff',
+  },
+  components: {
+    Layout: {
+      headerBg: '#110028',
+      siderBg: '#110028',
+    },
+    Menu: {
+      darkItemBg: '#110028',
+      darkSubMenuItemBg: '#080014',
+    }
   }
 }
 
 const lightTheme = {
   algorithm: [theme.defaultAlgorithm],
   token: {
-    colorPrimary: '#722ed1'
+    colorPrimary: '#722ed1',
+  },
+  components: {
+    Layout: {
+      headerBg: '#110028',
+      siderBg: '#110028',
+    },
+    Menu: {
+      darkItemBg: '#110028',
+      darkSubMenuItemBg: '#080014',
+    }
   }
 }
 


### PR DESCRIPTION
With the update to Ant Design V5, the method to change the theme was deprecated. I chose to temporarily use the default colors. Until now.

<img width="1671" alt="Screenshot 2023-11-28 at 11 55 32 PM" src="https://github.com/sophiedeziel/Tentacles/assets/1037105/330f4bfb-a816-4860-bf36-0fc243c9bc51">
