### PR TITLE
Reinstall sprockets in dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'activestorage', rails_version
 gem 'railties',      rails_version
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-# gem 'sprockets-rails'
+gem 'sprockets-rails'
 
 # Use sqlite3 as the database for Active Record
 # gem "sqlite3", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,6 +397,7 @@ DEPENDENCIES
   shakapacker (~> 7.1)
   sidekiq (~> 7.2)
   simplecov
+  sprockets-rails
   tzinfo-data
   vcr (~> 6.2)
   web-console


### PR DESCRIPTION
The commit that fixed Graphiql missed the step to list sprockets as a dependency. That broke the Docker image (or any new install).