### PR TITLE
Potential fix for code scanning alert no. 13: SQL query built from user-controlled sources

### DIFF
--- a/app/graphql/root_operations/query.rb
+++ b/app/graphql/root_operations/query.rb
@@ -47,7 +47,7 @@ module RootOperations
       argument :id, ID, required: true
     end
     def label(id:)
-      ::Label.find(id) if ::Label.exists?(id)
+      ::Label.find_by(id: id)
     end
 
     field :search_network_printers, [String], null: true


### PR DESCRIPTION
Potential fix for [https://github.com/sophiedeziel/Tentacles/security/code-scanning/13](https://github.com/sophiedeziel/Tentacles/security/code-scanning/13)

To fix the problem, we need to ensure that the `id` parameter is properly sanitized and parameterized before being used in the SQL query. The best way to achieve this is by using ActiveRecord's parameterized query methods, which automatically handle sanitization and prevent SQL injection.

In this case, we can use the `find_by` method with a hash to parameterize the `id` argument. This ensures that the `id` is safely embedded into the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
