### PR TITLE
Potential fix for code scanning alert no. 12: SQL query built from user-controlled sources

### DIFF
--- a/app/graphql/root_operations/query.rb
+++ b/app/graphql/root_operations/query.rb
@@ -33,7 +33,7 @@ module RootOperations
       argument :id, ID, required: true
     end
     def file(id:)
-      ::FileRecord.find(id) if ::FileRecord.exists?(id)
+      ::FileRecord.find_by(id: id)
     end
 
     field :labels, Types::Label.connection_type, null: false do


### PR DESCRIPTION
Potential fix for [https://github.com/sophiedeziel/Tentacles/security/code-scanning/12](https://github.com/sophiedeziel/Tentacles/security/code-scanning/12)

To fix the problem, we should ensure that the `id` parameter is properly sanitized and parameterized before being used in the SQL query. The best way to achieve this is by using ActiveRecord's built-in methods that automatically handle parameterization.

- Replace the direct use of `::FileRecord.exists?(id)` and `::FileRecord.find(id)` with methods that ensure the `id` is properly parameterized.
- Specifically, use `::FileRecord.find_by(id: id)` which ensures that the `id` is treated as a parameterized value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
