### PR TITLE
Optimize Docker workflow to run only on relevant file changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,8 +12,34 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+    paths:
+      - 'Dockerfile'
+      - 'docker-compose.yml'
+      - 'docker-compose.*.yml'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - 'app/**'
+      - 'bin/**'
+      - 'config/**'
+      - 'db/**'
+      - 'lib/**'
+      - 'public/**'
+      - '.dockerignore'
+      - '.github/workflows/docker-publish.yml'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'Dockerfile'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'yarn.lock'
+      - '.dockerignore'
+      - '.github/workflows/docker-publish.yml'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
## Summary
- Added path filters to Docker workflow triggers to reduce unnecessary builds
- Pull requests now only trigger Docker builds when files affecting the image are changed
- Pushes to main trigger on broader set of files to ensure production images stay updated

## Test plan
- [ ] Verify workflow runs on PRs that modify Dockerfile or dependencies
- [ ] Verify workflow skips on PRs that only modify application code
- [ ] Verify workflow still runs on pushes to main with relevant changes
- [ ] Verify scheduled runs continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)