### PR TITLE
Fix CI error: add checkout step before using custom actions

### DIFF
--- a/.github/actions/setup-rails/action.yml
+++ b/.github/actions/setup-rails/action.yml
@@ -8,9 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
     - uses: ./.github/actions/setup-ruby
     
     - uses: ./.github/actions/setup-node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,9 @@ jobs:
       CI_NODE_INDEX: ${{ matrix.group }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
       - uses: ./.github/actions/setup-rails
         with:
           setup-database: 'true'
@@ -139,6 +142,9 @@ jobs:
       RAILS_ENV: production
       SECRET_KEY_BASE: precompile_placeholder
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      
       - uses: ./.github/actions/setup-rails
         with:
           setup-database: 'false'


### PR DESCRIPTION
## Summary
- Fixes CI error where custom actions couldn't be found
- Resolves issue in GitHub Actions run where setup-rails action failed with "Can't find 'action.yml'"

## Root Cause
The `setup-rails` custom action included a checkout step, but GitHub Actions requires the repository to be checked out first before it can find and use custom actions from `.github/actions/`.

## Changes
- Remove checkout step from `.github/actions/setup-rails/action.yml`
- Add checkout steps to workflows in `.github/workflows/main.yml` before calling setup-rails action
- Updated both `rspec` and `javascript-and-assets` jobs

## Test plan
- [x] Verify action.yml syntax is valid
- [x] Confirm workflows reference the action correctly
- [ ] CI should now pass without the checkout error

🤖 Generated with [Claude Code](https://claude.ai/code)