### PR TITLE
Build(deps): Bump shakapacker from 8.3 to 8.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'octoprint', github: 'sophiedeziel/octoprint', branch: 'main' # For prototyp
 gem 'bindex' # shakapacker won't work without this
 gem 'mini_racer', platforms: :ruby
 gem 'react_on_rails', '~> 15.0.0'
-gem 'shakapacker', '~> 8.3'
+gem 'shakapacker', '~> 8.4'
 
 gem 'colorize'
 gem 'pry' # TODO: fix octoprint gem to not require pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     semantic_range (3.1.0)
-    shakapacker (8.3.0)
+    shakapacker (8.4.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -482,7 +482,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.33)
   rubocop-rspec
   selenium-webdriver
-  shakapacker (~> 8.3)
+  shakapacker (~> 8.4)
   sidekiq (~> 7.3)
   simplecov
   sorbet-static-and-runtime (~> 0.6.12507)


### PR DESCRIPTION
## Summary
- Updates shakapacker gem from version ~> 8.3 to ~> 8.4
- Brings in latest shakapacker improvements and bug fixes

## Test plan
- [x] Bundle update completed successfully without conflicts
- [x] Rails application boots correctly after update
- [ ] Manual testing to ensure assets compile and JavaScript functionality works as expected